### PR TITLE
Really linkify the links on the bottom

### DIFF
--- a/index_includes/learn.html
+++ b/index_includes/learn.html
@@ -30,29 +30,29 @@
       <h3>Resources:</h3>
       <p>
       </p>
-      
+
       <ul>
-        <li><strong>Five Facts About Gender Pay Gap:</strong> <a href="https://www.whitehouse.gov/blog/2015/04/14/five-facts-about-gender-pay-gap"></a>https://www.whitehouse.gov/blog/2015/04/14/five-facts-about-gender-pay-gap</a></li>
+        <li><strong>Five Facts About Gender Pay Gap:</strong> <a href="https://www.whitehouse.gov/blog/2015/04/14/five-facts-about-gender-pay-gap">https://www.whitehouse.gov/blog/2015/04/14/five-facts-about-gender-pay-gap</a></li>
 
-        <li><strong>Fact Sheet: New Steps to Advance Equal Pay on the Seventh Anniversary of the Lilly Ledbetter Fair Pay Act:</strong> <a href="https://www.whitehouse.gov/the-press-office/2016/01/29/fact-sheet-new-steps-advance-equal-pay-seventh-anniversary-lilly"></a>https://www.whitehouse.gov/the-press-office/2016/01/29/fact-sheet-new-steps-advance-equal-pay-seventh-anniversary-lilly</a></li>
+        <li><strong>Fact Sheet: New Steps to Advance Equal Pay on the Seventh Anniversary of the Lilly Ledbetter Fair Pay Act:</strong> <a href="https://www.whitehouse.gov/the-press-office/2016/01/29/fact-sheet-new-steps-advance-equal-pay-seventh-anniversary-lilly">https://www.whitehouse.gov/the-press-office/2016/01/29/fact-sheet-new-steps-advance-equal-pay-seventh-anniversary-lilly</a></li>
 
-        <li><strong>Issue Brief: The Gender Pay Gap on the Anniversary of the Lilly Ledbetter Fair Pay Act:</strong> <a href="https://www.whitehouse.gov/sites/default/files/page/files/20160128_cea_gender_pay_gap_issue_brief.pdf"></a>https://www.whitehouse.gov/sites/default/files/page/files/20160128_cea_gender_pay_gap_issue_brief.pdf</a></li>
+        <li><strong>Issue Brief: The Gender Pay Gap on the Anniversary of the Lilly Ledbetter Fair Pay Act:</strong> <a href="https://www.whitehouse.gov/sites/default/files/page/files/20160128_cea_gender_pay_gap_issue_brief.pdf">https://www.whitehouse.gov/sites/default/files/page/files/20160128_cea_gender_pay_gap_issue_brief.pdf</a></li>
 
       </ul>
 
-            
+
 
     </div>
 
     <div class="usa-width-one-third">
-      
+
       <a href="https://www.whitehouse.gov/the-press-office/2016/01/29/fact-sheet-new-steps-advance-equal-pay-seventh-anniversary-lilly">
         <!--
         <img src="{{ "img/equalpay-factsheet.png" | prepend: site.baseurl }}"
              alt="White House Fact Sheet" class="ood-fact-sheet">
         -->
       </a>
-   
+
     </div>
   </div>
 


### PR DESCRIPTION
#25 was incomplete, I had accidentally included duplicate `</a>` closing tags. It didn't cause any regressions or bugs, they just didn't actually end up linking. This fixes that.
