### PR TITLE
Use new slackin domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Test Coverage](https://codeclimate.com/github/presidential-innovation-fellows/hack-the-paygap/badges/coverage.svg)](https://codeclimate.com/github/presidential-innovation-fellows/hack-the-paygap/coverage)
 [![Issue Count](https://codeclimate.com/github/presidential-innovation-fellows/hack-the-paygap/badges/issue_count.svg)](https://codeclimate.com/github/presidential-innovation-fellows/hack-the-paygap)
 
-[![Slack Status](https://hackthepaygap.herokuapp.com/badge.svg)](https://hackthepaygap.herokuapp.com)
+[![Slack Status](https://paygap-slack.pif.gov/badge.svg)](https://paygap-slack.pif.gov/)
 
 Reducing the gender pay gap using data
 

--- a/index_includes/connect.html
+++ b/index_includes/connect.html
@@ -14,7 +14,7 @@
       <h3>Join the community</h3>
       <p> Data is one of the most powerful tools we have to accelerate change. Leveraging <a href=" https://midaas.commerce.gov/" target="_blank">newly-released income data</a> from the U.S. Census, how might we work together to decrease the gender pay gap and increase the economic empowerment of women? </p>
       <p><strong>Connect with us on our Slack Channel and on Github.</strong></p>
-      <a href="https://hackthepaygap.herokuapp.com/"
+      <a href="https://paygap-slack.pif.gov/"
          class="usa-button usa-button-big" target="_blank">Join Us in Slack<i class="fa fa-slack fa-fw"></i></a>
 
       <a href="{{ site.repo_url }}"

--- a/index_includes/pledge.html
+++ b/index_includes/pledge.html
@@ -12,7 +12,7 @@
       <p>
         We invite you to connect with us in our Slack chat and on our GitHub page.
       </p>
-      <a href="https://hackthepaygap.herokuapp.com/" class="usa-button usa-button-big">
+      <a href="https://paygap-slack.pif.gov/" class="usa-button usa-button-big">
          Share A Story
          <i class="fa fa-comment"></i>
        </a>

--- a/index_includes/recap.html
+++ b/index_includes/recap.html
@@ -19,7 +19,7 @@
   </p>
 
   <div class="ood-join">
-    <a href="https://hackthepaygap.herokuapp.com/"
+    <a href="https://paygap-slack.pif.gov/"
        class="usa-button usa-button-big">Join Us in Slack<i class="fa fa-slack fa-fw"></i></a>
     <a href="{{ site.repo_url }}"
        class="usa-button usa-button-outline usa-button-big">Join Us on GitHub<i class="fa fa-github fa-fw"></i></a>

--- a/index_includes/women.html
+++ b/index_includes/women.html
@@ -12,7 +12,7 @@
       <p>
         Help build momentum for equal pay for women by commiting to ask for a raise.
       </p>
-      <a href="https://hackthepaygap.herokuapp.com/" class="usa-button usa-button-big">
+      <a href="https://paygap-slack.pif.gov/" class="usa-button usa-button-big">
          Commit to asking
          <i class="fa fa-comment"></i>
        </a>


### PR DESCRIPTION
Please update all existing references as well (Medium article, etc.) to https://paygap-slack.pif.gov/
