### PR TITLE
remove extra closing bracket

### DIFF
--- a/_includes/disclaimer.html
+++ b/_includes/disclaimer.html
@@ -2,7 +2,7 @@
   <div class="usa-grid">
     <span class="usa-disclaimer-official">
       <img class="usa-flag_icon"
-           src="{{ site.baseurl }}/scss/web-design-standards/img/us_flag_small.png">
+           src="{{ site.baseurl }}/scss/web-design-standards/img/us_flag_small.png"
            alt="US flag signifying that this is a United States Federal Government website">
       An official website of the United States Government
     </span>


### PR DESCRIPTION
alt text is showing on the rendered website due to an extra HTML angle bracket; this PR fixes it